### PR TITLE
Fix python3 compatibility

### DIFF
--- a/scripts/hr-analytics-analyse-data.py
+++ b/scripts/hr-analytics-analyse-data.py
@@ -28,7 +28,7 @@ sns.set(style="white")
 corr = data.corr()
 
 # Generate a mask for the upper triangle
-mask = np.zeros_like(corr, dtype=np.bool)
+mask = np.zeros_like(corr, dtype=bool)
 mask[np.triu_indices_from(mask)] = True
 
 # Set up the matplotlib figure
@@ -99,15 +99,19 @@ key_employees.describe()
 # In[135]:
 
 #lost key employees
-lost_key_employees = key_employees.loc[data['left']==1]
+lost_key_employees = key_employees.loc[key_employees['left'] == 1]
 lost_key_employees.describe()
 
 
 # In[151]:
 
-print "Number of key employees: ", len(key_employees)
-print "Number of lost key employees: ", len(lost_key_employees)
-print "Percentage of lost key employees: ", round((float(len(lost_key_employees))/float(len(key_employees))*100),2),"%"
+print("Number of key employees: ", len(key_employees))
+print("Number of lost key employees: ", len(lost_key_employees))
+print(
+    "Percentage of lost key employees: ",
+    round((float(len(lost_key_employees)) / float(len(key_employees)) * 100), 2),
+    "%",
+)
 
 
 # In[152]:
@@ -132,7 +136,7 @@ sns.set(style="white")
 corr = leaving_performers.corr()
 
 # Generate a mask for the upper triangle
-mask = np.zeros_like(corr, dtype=np.bool)
+mask = np.zeros_like(corr, dtype=bool)
 mask[np.triu_indices_from(mask)] = True
 
 # Set up the matplotlib figure
@@ -163,7 +167,7 @@ sns.set(style="white")
 corr = satisfied_employees.corr()
 
 # Generate a mask for the upper triangle
-mask = np.zeros_like(corr, dtype=np.bool)
+mask = np.zeros_like(corr, dtype=bool)
 mask[np.triu_indices_from(mask)] = True
 
 # Set up the matplotlib figure

--- a/scripts/hr-analytics-predict-leave-proba.py
+++ b/scripts/hr-analytics-predict-leave-proba.py
@@ -18,10 +18,10 @@ leave_df = pd.read_csv('../data/raw_data.csv')
 col_names = leave_df.columns.tolist()
 
 #show some basic output
-print "Column names:"
-print col_names
+print("Column names:")
+print(col_names)
 
-print "\nSample data:"
+print("\nSample data:")
 leave_df.head(6)
 
 
@@ -44,14 +44,14 @@ le_sales.fit(leave_feat_space["department"])
 leave_feat_space["department"] = le_sales.transform(leave_feat_space.loc[:,('department')])
 
 # transforme the whole feature space into a matrix
-X = leave_feat_space.as_matrix().astype(np.float)
+X = leave_feat_space.values.astype(float)
 
 # standardize all features
 scaler = preprocessing.StandardScaler()
 X = scaler.fit_transform(X)
 
-print "Feature space holds %d observations and %d features" % X.shape
-print "Unique target labels:", np.unique(y)
+print("Feature space holds %d observations and %d features" % X.shape)
+print("Unique target labels:", np.unique(y))
 
 
 # In[4]:
@@ -80,12 +80,12 @@ def accuracy(y, predicted):
     # NumPy interprets True and False as 1. and 0.
     return metrics.accuracy_score(y, predicted)
 
-print "Support vector machines:"
-print "%.3f" % accuracy(y, run_cv(X,y,SVC, method='predict'))
-print "Random forest:"
-print "%.3f" % accuracy(y, run_cv(X,y,RF, method='predict'))
-print "K-nearest-neighbors:"
-print "%.3f" % accuracy(y, run_cv(X,y,KNN, method='predict'))
+print("Support vector machines:")
+print("%.3f" % accuracy(y, run_cv(X, y, SVC, method='predict')))
+print("Random forest:")
+print("%.3f" % accuracy(y, run_cv(X, y, RF, method='predict')))
+print("K-nearest-neighbors:")
+print("%.3f" % accuracy(y, run_cv(X, y, KNN, method='predict')))
 
 
 # In[6]:
@@ -103,7 +103,7 @@ confusion_matrices = [
 ]
 
 # show confusion matrix values
-print confusion_matrices
+print(confusion_matrices)
 
 
 # In[7]:
@@ -138,7 +138,7 @@ counts = pd.value_counts(pred_leave)
 true_prob = {}
 for prob in counts.index:
     true_prob[prob] = np.mean(is_leave[pred_leave == prob])
-    true_prob = pd.Series(true_prob)
+true_prob = pd.Series(true_prob)
 
 # pandas-fu
 counts = pd.concat([counts,true_prob], axis=1).reset_index()


### PR DESCRIPTION
## Summary
- fix SyntaxError due to Python 2 print statements
- use `.values` instead of deprecated `as_matrix`
- correct lost key employee filter
- avoid deprecated `np.bool`
- fix probability calculation loop

## Testing
- `python3 -m py_compile scripts/hr-analytics-predict-leave-proba.py && python3 -m py_compile scripts/hr-analytics-analyse-data.py`

------
https://chatgpt.com/codex/tasks/task_e_683f63e6f8748323b3a2e37690e2ea23